### PR TITLE
Remove 'fs' and 'path' dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   },
   "homepage": "https://github.com/jogaram/environment-variables-webpack-plugin#readme",
   "dependencies": {
-    "chalk": "^1.1.3",
-    "fs": "0.0.2",
-    "path": "^0.12.7"
+    "chalk": "^1.1.3"
   }
 }


### PR DESCRIPTION
Ref: https://www.npmjs.com/package/fs

Both `fs` and `path` are native Node modules and don't need to be in dependencies, and you almost certainly don't want them via npm.
